### PR TITLE
Feature/docker deployment

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -68,7 +68,7 @@ RUN mkdir -p \
         /cwlab/database && \
     chmod -R 777 /cwlab
 
-COPY config.yaml /cwlab/config.yaml
+COPY config.yaml /etc/cwlab/config.yaml
 
 # Default command when starting:
-CMD ["cwlab", "up", "-c", "/cwlab/config.yaml"]
+CMD ["cwlab", "up", "-c", "/etc/cwlab/config.yaml"]

--- a/docker/dev/config.yaml
+++ b/docker/dev/config.yaml
@@ -2,10 +2,11 @@ WEB_SERVER_HOST: 0.0.0.0
 WEB_SERVER_PORT: 5000 
 
 TEMP_DIR: '/cwlab/tmp'
-WORKFLOW_DIR: '/cwlab/worlflows'
+WORKFLOW_DIR: '/cwlab/workflows'
 EXEC_DIR: '/cwlab/exec'
 INPUT_DIR: '/cwlab/input'
 DB_DIR: '/cwlab/database'
+ENABLE_USERS: False
 
 DEBUG: False
 


### PR DESCRIPTION
Move the config file out of /cwlab, so that it will be possible to mount a host path into the container to store all cwlab related data. The old variant required to provide a own config file in that case. 